### PR TITLE
fix: null guard in PatchDamageAction to prevent NPE with other mods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <SlayTheSpire.version>12-22-2020</SlayTheSpire.version>
         <ModTheSpire.version>3.23.2</ModTheSpire.version>
         <Steam.path>E:\SteamLibrary\steamapps</Steam.path>
@@ -78,7 +80,7 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/FrierenMod/patches/PatchDamageAction.java
+++ b/src/main/java/FrierenMod/patches/PatchDamageAction.java
@@ -19,7 +19,7 @@ public class PatchDamageAction {
     public static class PatchConstructor {
         @SpirePostfixPatch
         public static void PostFix(DamageAction __instance, AbstractCreature target, DamageInfo info, AbstractGameAction.AttackEffect effect) {
-            if (info.owner.equals(AbstractDungeon.player) && target != AbstractDungeon.player && AbstractDungeon.player.hasPower(FumeshroomFormPower.POWER_ID)) {
+            if (info.owner != null && info.owner == AbstractDungeon.player && target != AbstractDungeon.player && AbstractDungeon.player.hasPower(FumeshroomFormPower.POWER_ID)) {
                 DamageActionField.backUpAction.set(__instance, new DamageAllEnemiesAction((AbstractPlayer) info.owner, info.base, info.type, effect));
             }
         }
@@ -29,9 +29,10 @@ public class PatchDamageAction {
     public static class PatchUpdate {
         @SpirePrefixPatch
         public static SpireReturn<Void> Prefix(DamageAction __instance) {
-            if (DamageActionField.backUpAction.get(__instance) != null) {
-                DamageActionField.backUpAction.get(__instance).update();
-                if (DamageActionField.backUpAction.get(__instance).isDone) {
+            AbstractGameAction backUp = DamageActionField.backUpAction.get(__instance);
+            if (backUp != null) {
+                backUp.update();
+                if (backUp.isDone) {
                     __instance.isDone = true;
                 }
                 return SpireReturn.Return(null);


### PR DESCRIPTION
## Problem

`PatchDamageAction.PatchConstructor` patches the `DamageAction` constructor globally.
When other mods create a `DamageAction` with `DamageInfo.owner = null` (valid usage for
THORNS-type damage without an owner), the patch throws a `NullPointerException` at line 22:

if (info.owner.equals(AbstractDungeon.player) ...  // NPE when owner is null

Crash log:
java.lang.NullPointerException
    at FrierenMod.patches.PatchDamageAction$PatchConstructor.PostFix(PatchDamageAction.java:22)
    at com.megacrit.cardcrawl.actions.common.DamageAction.<init>(DamageAction.java:28)

## Changes

- Add `info.owner != null` guard to prevent NPE
- Replace `info.owner.equals(player)` with `info.owner == player` (reference identity is correct here)
- Extract repeated `DamageActionField.backUpAction.get(__instance)` call to a local variable in `PatchUpdate`
